### PR TITLE
Fix LDAP delta inbound to pull all changes

### DIFF
--- a/rbac/providers/ldap/delta_inbound_sync.py
+++ b/rbac/providers/ldap/delta_inbound_sync.py
@@ -36,13 +36,14 @@ LDAP_PASS = os.getenv("LDAP_PASS")
 USER_BASE_DN = os.getenv("USER_BASE_DN")
 GROUP_BASE_DN = os.getenv("GROUP_BASE_DN")
 DELTA_SYNC_INTERVAL_SECONDS = int(os.getenv("DELTA_SYNC_INTERVAL_SECONDS", "3600"))
+LDAP_SEARCH_PAGE_SIZE = 500
 
 LOGGER = get_default_logger(__name__)
 
 
 def fetch_ldap_data():
     """
-        Call to get entries for (Users | Groups) in Active Directory, saves the time of the sync,
+        Call to get entries for (Users & Groups) in Active Directory, saves the time of the sync,
         and inserts data into RethinkDB.
     """
     LOGGER.debug("Connecting to RethinkDB...")
@@ -51,56 +52,64 @@ def fetch_ldap_data():
 
     for data_type in ["user", "group"]:
         if data_type == "user":
-            last_sync = (
-                r.table("sync_tracker")
-                .filter({"provider_id": LDAP_DC, "source": "ldap-user"})
-                .max("timestamp")
-                .coerce_to("object")
-                .run(conn)
-            )
-            last_sync_time = last_sync["timestamp"]
-            last_sync_time_formatted = to_date_ldap_query(
-                rethink_timestamp=last_sync_time
-            )
-            search_filter = (
-                "(&(objectClass=person)(whenChanged>=%s))" % last_sync_time_formatted
-            )
+            ldap_source = "ldap-user"
             search_base = USER_BASE_DN
-
+            object_class = "person"
         else:
-            last_sync = (
-                r.table("sync_tracker")
-                .filter({"provider_id": LDAP_DC, "source": "ldap-group"})
-                .max("timestamp")
-                .coerce_to("object")
-                .run(conn)
-            )
-            last_sync_time = last_sync["timestamp"]
-            last_sync_time_formatted = to_date_ldap_query(
-                rethink_timestamp=last_sync_time
-            )
-            search_filter = (
-                "(&(objectClass=group)(whenChanged>=%s))" % last_sync_time_formatted
-            )
+            ldap_source = "ldap-group"
             search_base = GROUP_BASE_DN
+            object_class = "group"
+        last_sync = (
+            r.table("sync_tracker")
+            .filter({"provider_id": LDAP_DC, "source": ldap_source})
+            .max("timestamp")
+            .coerce_to("object")
+            .run(conn)
+        )
+        last_sync_time = last_sync["timestamp"]
+        last_sync_time_formatted = to_date_ldap_query(rethink_timestamp=last_sync_time)
+        search_filter = "(&(objectClass=%s)(whenChanged>=%s))" % (
+            object_class,
+            last_sync_time_formatted,
+        )
         ldap_connection = ldap_connector.await_connection(
             LDAP_SERVER, LDAP_USER, LDAP_PASS
         )
-
-        ldap_connection.search(
-            search_base=search_base,
-            search_filter=search_filter,
-            attributes=ldap3.ALL_ATTRIBUTES,
-        )
-
         parsed_last_sync_time = datetime.strptime(
             last_sync_time.split("+")[0], "%Y-%m-%dT%H:%M:%S.%f"
         ).replace(tzinfo=timezone.utc)
-        insert_to_db(
-            data_dict=ldap_connection.entries,
-            when_changed=parsed_last_sync_time,
-            data_type=data_type,
-        )
+        search_parameters = {
+            "search_base": search_base,
+            "search_filter": search_filter,
+            "attributes": ldap3.ALL_ATTRIBUTES,
+            "paged_size": LDAP_SEARCH_PAGE_SIZE,
+        }
+        entry_count = 0
+        LOGGER.info("Importing %ss..", data_type)
+        while True:
+            start_time = time.clock()
+            ldap_connection.search(**search_parameters)
+            record_count = len(ldap_connection.entries)
+            LOGGER.info(
+                "Got %s entries in %s seconds.",
+                record_count,
+                "%.3f" % (time.clock() - start_time),
+            )
+            entry_count = entry_count + len(ldap_connection.entries)
+            insert_to_db(
+                data_dict=ldap_connection.entries,
+                when_changed=parsed_last_sync_time,
+                data_type=data_type,
+            )
+            # 1.2.840.113556.1.4.319 is the OID/extended control for PagedResults
+            cookie = ldap_connection.result["controls"]["1.2.840.113556.1.4.319"][
+                "value"
+            ]["cookie"]
+            if cookie:
+                search_parameters["paged_cookie"] = cookie
+            else:
+                LOGGER.info("Imported %s entries from Active Directory", entry_count)
+                break
     conn.close()
 
 


### PR DESCRIPTION
Fixed the fetch_ldap_data() in delta_inbound_sync work more like the initial inbound version, using the ldap pagination to get all results instead of default limit. 
