### PR TITLE
Bootstrap initial app admin user and role

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,6 +28,7 @@ node_modules
 npm-debug.log
 Dockerfile*
 docker-compose*
+.env
 .dockerignore
 .git
 .gitignore

--- a/.env.example
+++ b/.env.example
@@ -19,14 +19,21 @@ limitations under the License.
 <!--============================================================================
 = Required global config variables                                             =
 =============================================================================-->
-# ENABLE_NEXT_BASE_USE allows user to be created by anyone who can access the
-# login portal.  It is an int field in boolean format (1 = True, 0 = False)
-ENABLE_NEXT_BASE_USE=1
-
 ISOLATION_ID=latest
 LOGGING_LEVEL=INFO
 #  Uncomment if using Windows for development.
 # COMPOSE_CONVERT_WINDOWS_PATHS=1
+
+<!--============================================================================
+= init variables                                                               =
+=============================================================================-->
+# ENABLE_NEXT_BASE_USE allows user to be created by anyone who can access the
+# login portal.  It is an int field in boolean format (1 = True, 0 = False)
+ENABLE_NEXT_BASE_USE=1
+NEXT_ADMIN_NAME=Next Administrator
+NEXT_ADMIN_USER=NextAdmin
+NEXT_ADMIN_PASS=ReplaceWithSecurePassword
+NEXT_ADMIN_EMAIL=next.admin@email.com
 
 <!--============================================================================
 = rbac-server config variables                                                 =

--- a/bin/stop
+++ b/bin/stop
@@ -1,1 +1,19 @@
-docker-compose down
+#!/usr/bin/env bash
+
+# Copyright 2019 Contributors to Hyperledger Sawtooth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+# remove all containers/network created by Compose.
+docker-compose down --remove-orphans

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -117,6 +117,10 @@ services:
       - SERVER_PORT=${SERVER_PORT:-8000}
       - SECRET_KEY=${SECRET_KEY}
       - TENANT_ID=${TENANT_ID}
+      - NEXT_ADMIN_NAME=${NEXT_ADMIN_NAME}
+      - NEXT_ADMIN_USER=${NEXT_ADMIN_USER}
+      - NEXT_ADMIN_PASS=${NEXT_ADMIN_PASS}
+      - NEXT_ADMIN_EMAIL=${NEXT_ADMIN_EMAIL}
     command: ./bin/rbac-server --db-host rethink --validator-host validator
 
   rethink:


### PR DESCRIPTION
* Add `.env` to `.dockerignore` (to prevent it from being mounted in volumes).
* Add copyright info to `./bin/stop` script.
* Add `--remove-orphans` flag to `docker-compose down` in `./bin/stop`.
* Create a NEXT admin user in `./rbac/server/api/main.py:init()`.
* Create a NextAdmins role in `./rbac/server/api/main.py:init()`.
* Add the NEXT admin user as owner and administrator of NextAdmins role.
* Add the NEXT admin user as a member of NextAdmins.

[ User Story: 200 ]

Signed-off-by: jbobo <j.ned@bobonana.me>