### PR TITLE
Set default value for DELTA_SYNC_INTERVAL_SECONDS

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -75,7 +75,7 @@ services:
     volumes:
       - ".:/project/hyperledger-rbac"
     environment:
-      - DELTA_SYNC_INTERVAL_SECONDS=${DELTA_SYNC_INTERVAL_SECONDS}
+      - DELTA_SYNC_INTERVAL_SECONDS=${DELTA_SYNC_INTERVAL_SECONDS:-3600}
       - ENABLE_LDAP_SYNC=${ENABLE_LDAP_SYNC:-False}
       - GROUP_BASE_DN=${GROUP_BASE_DN}
       - LDAP_DC=${LDAP_DC}


### PR DESCRIPTION
* If DELTA_SYNC_INTERVAL_SECONDS is not set in .env it defaults to an empty
  string which breaks the `rbac_provider_ldap` container. Setting
  docker-compose.yml to default to 3600 instead of an empty string if the
  environment variable is missing.

[ Ticket: #367 ]

Signed-off-by: jbobo <j.ned@bobonana.me>