### PR TITLE
Update state ONLY after updating db tables

### DIFF
--- a/rbac/ledger_sync/deltas/updating.py
+++ b/rbac/ledger_sync/deltas/updating.py
@@ -262,10 +262,9 @@ def _update(conn, block_num, address, resource):
     data_type = addresser.get_address_type(address)
     pre_filter(resource)
 
-    _update_state(conn, block_num, address, resource)
-
     if data_type in TABLE_NAMES:
         _update_legacy(conn, block_num, address, resource, data_type)
+        _update_state(conn, block_num, address, resource)
         _update_provider(conn, data_type, resource)
 
 


### PR DESCRIPTION
* Objects from the sawtooth changefeed were being inserted into the outbound
  queue before being upserted in RethinkDB.
* The _update_state() function checked RethinkDB for role objects before
  putting them in the outbound queue. If a role was not found then
  _update_state() returned no value, causing ledger_sync to exit. This resulted
  in a bug that broke ledger-sync whenever a role was created in NEXT (as
  opposed to being ingested through a remote proveder or injected directly in
  rethinkDB.)

* The fix was to invoke _update_state() after invoking _update_legacy()

[ Bug: #429 ]

Signed-off-by: jbobo <j.ned@bobonana.me>