### PR TITLE
Add delete role api endpoint

### DIFF
--- a/rbac/ledger_sync/inbound/rbac_transactions.py
+++ b/rbac/ledger_sync/inbound/rbac_transactions.py
@@ -36,7 +36,7 @@ from rbac.providers.common.db_queries import connect_to_db
 from rbac.server.api.proposals import PROPOSAL_TRANSACTION
 from rbac.server.db.proposals_query import (
     fetch_open_proposals_by_opener,
-    fetch_open_proposals_by_target,
+    fetch_open_proposals_by_role,
     get_open_proposals_by_approver,
 )
 from rbac.server.db.relationships_query import fetch_relationship_query
@@ -444,7 +444,7 @@ def create_reject_ppsls_role_txns(key_pair, next_id, txn_list):
                list: transactions for batch submission
     """
     conn = connect_to_db()
-    proposals = fetch_open_proposals_by_target(next_id).coerce_to("array").run(conn)
+    proposals = fetch_open_proposals_by_role(conn, next_id)
     conn.close()
     if proposals:
         for proposal in proposals:

--- a/rbac/server/api/users.py
+++ b/rbac/server/api/users.py
@@ -38,9 +38,9 @@ from rbac.common.logs import get_default_logger
 from rbac.common.sawtooth import batcher
 from rbac.server.blockchain_transactions.user_transaction import create_delete_user_txns
 from rbac.server.blockchain_transactions.role_transaction import (
-    create_delete_role_owner_txns,
-    create_delete_role_admin_txns,
-    create_delete_role_member_txns,
+    create_del_ownr_by_user_txns,
+    create_del_admin_by_user_txns,
+    create_del_mmbr_by_user_txns,
 )
 
 
@@ -240,9 +240,9 @@ async def delete_user(request, next_id):
     """Delete a specific user by next_id."""
     txn_list = []
     txn_key, _ = await utils.get_transactor_key(request)
-    txn_list = await create_delete_role_owner_txns(txn_key, next_id, txn_list)
-    txn_list = await create_delete_role_admin_txns(txn_key, next_id, txn_list)
-    txn_list = await create_delete_role_member_txns(txn_key, next_id, txn_list)
+    txn_list = await create_del_ownr_by_user_txns(txn_key, next_id, txn_list)
+    txn_list = await create_del_admin_by_user_txns(txn_key, next_id, txn_list)
+    txn_list = await create_del_mmbr_by_user_txns(txn_key, next_id, txn_list)
     txn_list = create_delete_user_txns(txn_key, next_id, txn_list)
 
     if txn_list:

--- a/rbac/server/blockchain_transactions/role_transaction.py
+++ b/rbac/server/blockchain_transactions/role_transaction.py
@@ -15,15 +15,20 @@
 """ Common Transaction Creation
 """
 import rethinkdb as r
+from rbac.server.api.proposals import PROPOSAL_TRANSACTION
 from rbac.server.db.db_utils import create_connection
+from rbac.server.db.proposals_query import fetch_open_proposals_by_role
+from rbac.common.logs import get_default_logger
 from rbac.common.role.delete_role import DeleteRole
 from rbac.common.role.delete_role_admin import DeleteRoleAdmin
 from rbac.common.role.delete_role_owner import DeleteRoleOwner
 from rbac.common.role.delete_role_member import DeleteRoleMember
 from rbac.common.sawtooth import batcher
 
+LOGGER = get_default_logger(__name__)
 
-async def create_delete_role_txns(key_pair, next_id, txn_list):
+
+def create_del_role_txns(key_pair, role_id, txn_list):
     """Create the delete transactions for a role object.
     Args:
         key_pair:
@@ -37,7 +42,7 @@ async def create_delete_role_txns(key_pair, next_id, txn_list):
             list: extended list of transactions for batch submission
     """
     role_delete = DeleteRole()
-    message = role_delete.make(signer_keypair=key_pair, next_id=next_id)
+    message = role_delete.make(signer_keypair=key_pair, role_id=role_id)
     payload = role_delete.make_payload(
         message=message, signer_keypair=key_pair, signer_user_id=key_pair.public_key
     )
@@ -46,15 +51,104 @@ async def create_delete_role_txns(key_pair, next_id, txn_list):
     return txn_list
 
 
-async def create_delete_role_member_txns(key_pair, next_id, txn_list):
-    """Create the delete transactions for a member if user is an member of any roles.
+async def create_rjct_ppsls_role_txns(key_pair, role_id, txn_user_id, txn_list):
+    """Create the reject open proposals transactions for a role that has been
+    deleted.
     Args:
-           key_pair:
-               obj: public and private keys for user
-           next_id: next_
-               str: next_id to search for the roles where user is the admin
-           txn_list:
-               list: transactions for batch submission
+        key_pair:
+            obj: public and private keys for user
+        role_id:
+            str: role_id parameter of the targeted role to close proposals for
+        txn_list:
+            list: transactions for batch submission
+    Returns:
+        txn_list:
+            list: extended list of transactions for batch submission
+    """
+    conn = await create_connection()
+    proposals = await fetch_open_proposals_by_role(conn, role_id)
+    conn.close()
+    if proposals:
+        for proposal in proposals:
+            reason = "Target Role was deleted."
+            reject_proposal = PROPOSAL_TRANSACTION[proposal["proposal_type"]][
+                "REJECTED"
+            ]
+            reject_proposal_msg = reject_proposal.make(
+                signer_keypair=key_pair,
+                signer_user_id=txn_user_id,
+                proposal_id=proposal["proposal_id"],
+                object_id=proposal["object_id"],
+                related_id=proposal["related_id"],
+                reason=reason,
+            )
+            payload = reject_proposal.make_payload(
+                message=reject_proposal_msg,
+                signer_keypair=key_pair,
+                signer_user_id=key_pair.public_key,
+            )
+            transaction = batcher.make_transaction(
+                payload=payload, signer_keypair=key_pair
+            )
+            txn_list.extend([transaction])
+    else:
+        LOGGER.warning("No proposals found for role: %s", role_id)
+    return txn_list
+
+
+async def create_del_mmbr_by_role_txns(key_pair, role_id, txn_list):
+    """Create the delete transactions for a role. Used when fully deleting a role.
+    Args:
+        key_pair:
+            obj: public and private keys for user
+        role_id:
+            str: next_id of a role to search for
+        txn_list:
+            list: transactions for batch submission
+    Returns:
+        txn_list:
+            list: extended list of transactions for batch submission
+    """
+    conn = await create_connection()
+    role_members = (
+        await r.table("role_members")
+        .filter({"role_id": role_id})
+        .coerce_to("array")
+        .run(conn)
+    )
+    conn.close()
+    if role_members:
+        member_delete = DeleteRoleMember()
+        for member in role_members:
+            admin_delete_message = member_delete.make(
+                signer_keypair=key_pair,
+                related_id=member["related_id"],
+                role_id=member["role_id"],
+            )
+            payload = member_delete.make_payload(
+                message=admin_delete_message,
+                signer_keypair=key_pair,
+                signer_user_id=key_pair.public_key,
+            )
+            transaction = batcher.make_transaction(
+                payload=payload, signer_keypair=key_pair
+            )
+            txn_list.extend([transaction])
+    else:
+        LOGGER.info("No role_members found for role: %s", role_id)
+    return txn_list
+
+
+async def create_del_mmbr_by_user_txns(key_pair, next_id, txn_list):
+    """Create the delete transactions for a member if user is an member of any
+    roles.
+    Args:
+        key_pair:
+            obj: public and private keys for user
+        next_id: next_
+            str: next_id to search for the roles where user is the admin
+        txn_list:
+            list: transactions for batch submission
     Returns:
         txn_list:
             list: extended list of transactions for batch submission
@@ -82,15 +176,61 @@ async def create_delete_role_member_txns(key_pair, next_id, txn_list):
                 payload=payload, signer_keypair=key_pair
             )
             txn_list.extend([transaction])
+    else:
+        LOGGER.info("No role_members found for user: %s", next_id)
     return txn_list
 
 
-async def create_delete_role_owner_txns(key_pair, next_id, txn_list):
+async def create_del_ownr_by_role_txns(key_pair, role_id, txn_list):
+    """Create the delete transactions for role_owners. Used when fully deleting
+    a role.
+    Args:
+           key_pair:
+               obj: public and private keys for user
+           role_id:
+               str: next_id of the role to search for
+           txn_list:
+               list: transactions for batch submission
+    Returns:
+        txn_list:
+            list: extended list of transactions for batch submission
+    """
+    conn = await create_connection()
+    role_owners = (
+        await r.table("role_owners")
+        .filter({"role_id": role_id})
+        .coerce_to("array")
+        .run(conn)
+    )
+    conn.close()
+    if role_owners:
+        owner_delete = DeleteRoleOwner()
+        for owner in role_owners:
+            owner_delete_message = owner_delete.make(
+                signer_keypair=key_pair,
+                related_id=owner["related_id"],
+                role_id=owner["role_id"],
+            )
+            payload = owner_delete.make_payload(
+                message=owner_delete_message,
+                signer_keypair=key_pair,
+                signer_user_id=key_pair.public_key,
+            )
+            transaction = batcher.make_transaction(
+                payload=payload, signer_keypair=key_pair
+            )
+            txn_list.extend([transaction])
+    else:
+        LOGGER.info("No role_owners found for role: %s", role_id)
+    return txn_list
+
+
+async def create_del_ownr_by_user_txns(key_pair, next_id, txn_list):
     """Create the delete transactions for an owner if ownership of a role(s) exists.
     Args:
            key_pair:
                obj: public and private keys for user
-           next_id: next_
+           next_id:
                str: next_id to search for the roles where user is the admin
            txn_list:
                list: transactions for batch submission
@@ -121,16 +261,18 @@ async def create_delete_role_owner_txns(key_pair, next_id, txn_list):
                 payload=payload, signer_keypair=key_pair
             )
             txn_list.extend([transaction])
+    else:
+        LOGGER.info("No role_owners found for user: %s", next_id)
     return txn_list
 
 
-async def create_delete_role_admin_txns(key_pair, next_id, txn_list):
+async def create_del_admin_by_role_txns(key_pair, role_id, txn_list):
     """Create the delete transactions for an admin if user is an admin of any roles.
     Args:
            key_pair:
                obj: public and private keys for user
-           next_id: next_
-               str: next_id to search for the roles where user is the admin
+           role_id:
+               str: next_id of the role to search for
            txn_list:
                list: transactions for batch submission
     Returns:
@@ -138,18 +280,20 @@ async def create_delete_role_admin_txns(key_pair, next_id, txn_list):
             list: extended list of transactions for batch submission
     """
     conn = await create_connection()
-    roles = (
+    role_admins = (
         await r.table("role_admins")
-        .filter({"related_id": next_id})
+        .filter({"role_id": role_id})
         .coerce_to("array")
         .run(conn)
     )
     conn.close()
-    if roles:
+    if role_admins:
         admin_delete = DeleteRoleAdmin()
-        for role in roles:
+        for admin in role_admins:
             admin_delete_message = admin_delete.make(
-                signer_keypair=key_pair, related_id=next_id, role_id=role["role_id"]
+                signer_keypair=key_pair,
+                related_id=admin["related_id"],
+                role_id=admin["role_id"],
             )
             payload = admin_delete.make_payload(
                 message=admin_delete_message,
@@ -160,4 +304,47 @@ async def create_delete_role_admin_txns(key_pair, next_id, txn_list):
                 payload=payload, signer_keypair=key_pair
             )
             txn_list.extend([transaction])
+    else:
+        LOGGER.info("No role_admins found for role: %s", role_id)
+    return txn_list
+
+
+async def create_del_admin_by_user_txns(key_pair, next_id, txn_list):
+    """Create the delete transactions for an admin if user is an admin of any roles.
+    Args:
+           key_pair:
+               obj: public and private keys for user
+           next_id:
+               str: next_id to search for the roles where user is the admin
+           txn_list:
+               list: transactions for batch submission
+    Returns:
+        txn_list:
+            list: extended list of transactions for batch submission
+    """
+    conn = await create_connection()
+    role_admins = (
+        await r.table("role_admins")
+        .filter({"related_id": next_id})
+        .coerce_to("array")
+        .run(conn)
+    )
+    conn.close()
+    if role_admins:
+        admin_delete = DeleteRoleAdmin()
+        for admin in role_admins:
+            admin_delete_message = admin_delete.make(
+                signer_keypair=key_pair, related_id=next_id, role_id=admin["role_id"]
+            )
+            payload = admin_delete.make_payload(
+                message=admin_delete_message,
+                signer_keypair=key_pair,
+                signer_user_id=key_pair.public_key,
+            )
+            transaction = batcher.make_transaction(
+                payload=payload, signer_keypair=key_pair
+            )
+            txn_list.extend([transaction])
+    else:
+        LOGGER.info("No role_admins found for user: %s", next_id)
     return txn_list

--- a/rbac/server/db/proposals_query.py
+++ b/rbac/server/db/proposals_query.py
@@ -191,21 +191,6 @@ def fetch_open_proposals_by_opener(next_id):
     return resource
 
 
-def fetch_open_proposals_by_target(next_id):
-    """Fetch all open proposals where target is the given next_id.
-    Args:
-        next_id:
-            str: a user's next ID
-    """
-    resource = (
-        r.table("proposals")
-        .filter({"target_id": next_id, "status": "OPEN"})
-        .coerce_to("array")
-    )
-
-    return resource
-
-
 def fetch_open_proposals_by_role(conn, role_id):
     """Fetch all open proposals related to a role.
         Args:

--- a/rbac/server/db/roles_query.py
+++ b/rbac/server/db/roles_query.py
@@ -72,6 +72,46 @@ async def insert_to_outboundqueue(conn, outbound_entry):
     return outbound_result
 
 
+async def does_role_exist(conn, role_id):
+    """Checks if a role exists in rethinkdb.
+
+    Args:
+        conn:
+            obj: Rethinkdb connection object.
+        role_id:
+            str: Next ID for a given role.
+    Returns:
+        bool:
+            True: if the role was found in rethink.
+        bool:
+            False: if the tole was not found in rethink.
+    """
+    role = await r.table("roles").filter({"role_id": role_id}).count().run(conn)
+    return bool(role > 0)
+
+
+async def fetch_role_owners(conn, role_id):
+    """fetches a list of role owners for the given role id.
+    Args:
+        conn:
+            obj: RethinkDB connection object.
+        role_id:
+            str: Next ID for a given role.
+    Returns:
+        role_owners:
+            arr: <str>: a list of Next IDs of users registered as owners of the
+                        given role.
+    """
+    role_owners = (
+        await r.table("role_owners")
+        .filter({"role_id": role_id})
+        .get_field("related_id")
+        .coerce_to("array")
+        .run(conn)
+    )
+    return role_owners
+
+
 async def fetch_role_resource(conn, role_id):
     """Get a role resource by role_id."""
     resource = (


### PR DESCRIPTION
* Add `DELETE` endpoint at `/api/roles/<role_id>`.
  * Followed pattern established by delete_user at `/api/users/<user_id>`.
* Added queries to common modules to be reused.
* This is blocking #374, pushing the feature code now and I'll add
  integration tests to complete #287 in a second PR.

[ Ticket: #287 ]

Signed-off-by: jbobo <j.ned@bobonana.me>