### PR TITLE
Compare inbound and outbound queue before inserts

### DIFF
--- a/rbac/ledger_sync/deltas/updating.py
+++ b/rbac/ledger_sync/deltas/updating.py
@@ -225,11 +225,7 @@ def format_role(role_resource):
         remote_id = "CN=" + role_resource["name"] + "," + ENV("GROUP_BASE_DN")
     else:
         remote_id = role_resource["remote_id"]
-    return {
-        "description": role_resource["description"],
-        "members": role_resource["members"],
-        "remote_id": remote_id,
-    }
+    return {"members": role_resource["members"], "remote_id": remote_id}
 
 
 def get_provider(admin_identifier):
@@ -264,25 +260,13 @@ def _update_provider(conn, address_type, resource):
         resource: The resource data
     """
     outbound_types = {
-        AddressSpace.USER: "user",
         AddressSpace.ROLES_ATTRIBUTES: "role",
         AddressSpace.ROLES_MEMBERS: "role",
-        AddressSpace.ROLES_OWNERS: "role",
     }
     if address_type in outbound_types:
         # Get the object & format it.
         provider_action = ""
         direction = ""
-        if outbound_types[address_type] == "user":
-            user = get_user(conn, resource["next_id"])
-            if user:
-                formatted_resource = user[0]
-            else:
-                LOGGER.warning("User not found: %s", resource["next_id"])
-                return
-            admin_identifier = formatted_resource["username"]
-            data_type = "user"
-            direction = formatted_resource["metadata"].get("sync_direction", "")
         if outbound_types[address_type] == "role":
             role = get_role(conn, resource["role_id"])
             if role:

--- a/rbac/providers/common/provider_transforms.py
+++ b/rbac/providers/common/provider_transforms.py
@@ -99,3 +99,5 @@ GROUP_CREATION_TRANSFORM = {
     "owners": {"azure": "owners", "ldap": "managedBy"},
     "visibility": {"azure": "visibility", "ldap": None},
 }
+
+GROUP_OUTBOUND_TRANSFORM = ["members", "remote_id"]

--- a/rbac/providers/ldap/delta_inbound_sync.py
+++ b/rbac/providers/ldap/delta_inbound_sync.py
@@ -17,27 +17,28 @@
 import os
 import time
 from datetime import datetime, timezone
-import rethinkdb as r
-import ldap3
-from rbac.providers.common import ldap_connector
-from rbac.common.logs import get_default_logger
 
+import ldap3
+import rethinkdb as r
+
+from rbac.common.logs import get_default_logger
+from rbac.providers.common import ldap_connector
+from rbac.providers.common.db_queries import connect_to_db, save_sync_time
 from rbac.providers.common.inbound_filters import (
     inbound_user_filter,
     inbound_group_filter,
+    outbound_queue_filter,
 )
-from rbac.providers.common.db_queries import connect_to_db, save_sync_time
 
+DELTA_SYNC_INTERVAL_SECONDS = int(os.getenv("DELTA_SYNC_INTERVAL_SECONDS", "3600"))
+GROUP_BASE_DN = os.getenv("GROUP_BASE_DN")
 LDAP_DC = os.getenv("LDAP_DC")
+LDAP_SEARCH_PAGE_SIZE = 500
 LDAP_SERVER = os.getenv("LDAP_SERVER")
 LDAP_USER = os.getenv("LDAP_USER")
 LDAP_PASS = os.getenv("LDAP_PASS")
-USER_BASE_DN = os.getenv("USER_BASE_DN")
-GROUP_BASE_DN = os.getenv("GROUP_BASE_DN")
-DELTA_SYNC_INTERVAL_SECONDS = int(os.getenv("DELTA_SYNC_INTERVAL_SECONDS", "3600"))
-LDAP_SEARCH_PAGE_SIZE = 500
-
 LOGGER = get_default_logger(__name__)
+USER_BASE_DN = os.getenv("USER_BASE_DN")
 
 
 def fetch_ldap_changes():
@@ -108,7 +109,7 @@ def fetch_ldap_changes():
             if cookie:
                 search_parameters["paged_cookie"] = cookie
             else:
-                LOGGER.info("Imported %s entries from Active Directory", entry_count)
+                LOGGER.info("Found %s AD delta entries", entry_count)
                 break
     conn.close()
 
@@ -251,19 +252,25 @@ def insert_updated_entries(data_dict, when_changed, data_type):
                 "timestamp": entry_modified_timestamp,
                 "provider_id": LDAP_DC,
             }
-            LOGGER.debug(
-                "Inserting LDAP %s into inbound queue: %s",
-                data_type,
-                standardized_entry["remote_id"],
-            )
-            r.table("inbound_queue").insert(inbound_entry).run(conn)
 
+            is_entry_a_duplicate = None
+            if data_type == "group":
+                is_entry_a_duplicate = remove_outbound_duplicates(
+                    standardized_entry, conn
+                )
+            if not is_entry_a_duplicate:
+                LOGGER.debug(
+                    "Inserting LDAP %s into inbound queue: %s",
+                    data_type,
+                    standardized_entry["remote_id"],
+                )
+                r.table("inbound_queue").insert(inbound_entry).run(conn)
+                insertion_counter += 1
             sync_source = "ldap-" + data_type
             provider_id = LDAP_DC
             save_sync_time(
                 provider_id, sync_source, "delta", conn, entry_modified_timestamp
             )
-            insertion_counter += 1
     conn.close()
     LOGGER.info("Inserted %s records into inbound_queue.", insertion_counter)
 
@@ -284,3 +291,171 @@ def inbound_delta_sync():
         LOGGER.info(
             "LDAP Domain Controller is not provided, skipping LDAP delta syncs."
         )
+
+
+def remove_outbound_duplicates(entry_data, db_conn):
+    """Check outbound queue for matching `status: 'CONFIRMED'` entries
+    (indicates that we've ingested a change we recently pushed to provider)
+
+    Args:
+        entry_data:
+            obj:    data field of a valid NEXT object. This field will contain the
+                    remote_id and members field of the NEXT role object.
+        db_conn:
+            obj: An open RethinkDB connection object.
+    Returns:
+        bool:
+            True: Matching entries were found and removed from the outbound queue.
+            False: No matching entries were found in hte outbound queue.
+    """
+    remote_id = entry_data["remote_id"]
+    outbound_duplicates = get_outbound_duplicates(remote_id, db_conn)
+
+    matching_entries = get_matching_entries(entry_data, outbound_duplicates)
+    LOGGER.info(
+        "Found %s matching entries in the outbound queue.", len(matching_entries)
+    )
+
+    if matching_entries:
+        LOGGER.info("Deleting matching entries from the outbound queue.")
+
+        update_response = set_status_to_confirmed(matching_entries, db_conn)
+        log_rethink_response(update_response, "updated")
+
+        delete_outbound_entries(matching_entries, db_conn)
+
+        return True
+
+    LOGGER.info("No matching entries found in outbound queue. Ignoring...")
+    return False
+
+
+def get_outbound_duplicates(remote_id, db_conn):
+    """Get all outbound_queue entries with the same remote_id.
+
+    Args:
+        remote_id:
+            str:    The remote id of the role object used by the
+                    remote rbac provider.
+        db_conn:
+            obj:    An open RethinkDB connection object.
+    Returns:
+        outbound_duplicates:
+            list:   A list of RethinkDB group entries from the
+                    outbound queue that have the given remote id.
+    """
+    outbound_duplicates = (
+        r.table("outbound_queue")
+        .filter({"data": {"remote_id": remote_id}})
+        .coerce_to("array")
+        .run(db_conn)
+    )
+    return outbound_duplicates
+
+
+def get_matching_entries(entry_data, outbound_duplicates):
+    """Loop through rbac entries to find if any have matching `data` fields.
+    A matching `data` field indicates that the entry represents the same
+    transaction performed on a resource.
+
+    Args:
+        entry_data:
+            obj:    A dict containing a role RethinkDB entry.
+        outbound_duplicates:
+            list:   A list of role entries from RethinkDB representing
+                    transactions performed on a single resource.
+    Returns:
+        matching_entries:
+            list:   A list of any role entries with a data field
+                    matching the given entry_data.
+    """
+    filtered_entry_data = outbound_queue_filter(entry_data)
+    matching_entries = []
+    for entry in outbound_duplicates:
+        entry_match = True
+        outbound_entry_data = entry["data"]
+        for attribute in outbound_entry_data:
+            if isinstance(entry_data[attribute], list):
+                outbound_entry_data[attribute].sort()
+                filtered_entry_data[attribute].sort()
+            if outbound_entry_data[attribute] != filtered_entry_data[attribute]:
+                entry_match = False
+        if entry_match:
+            matching_entries.append(entry)
+    return matching_entries
+
+
+def set_status_to_confirmed(matching_entries, db_conn):
+    """Set the `status` of any matches to "CONFIRMED" if it's "UNCONFIRMED".
+
+    Args:
+        matching_entries:
+            list:   A list of role RethinkDB entries to modify.
+        db_conn:
+            obj:    An open RethinkDB connection object.
+    Returns:
+        update_response:
+            obj:    A dict containing the RethinkDB transaction response.
+    """
+    id_list = get_ids(matching_entries)
+    update_response = (
+        r.table("outbound_queue")
+        .get_all(id_list)
+        .update({"status": "CONFIRMED"})
+        .coerce_to("object")
+        .run(db_conn)
+    )
+    return update_response
+
+
+def delete_outbound_entries(matching_entries, db_conn):
+    """Delete the given entries from the DB.
+
+    Args:
+        matching_entries:
+            list:   A list of outbound_queue table entries to delete.
+        db_conn:
+            obj:    An open RethinkDB connection object.
+    """
+    id_list = get_ids(matching_entries)
+    for entry_id in id_list:
+        r.table("outbound_queue").get_all(entry_id).delete().coerce_to("object").run(
+            db_conn
+        )
+
+
+def get_ids(entries):
+    """Take in a list of entries and return a list of RethinkDB IDs.
+
+    Args:
+        entries:
+            list:   A list of dicts containing user|role RethinkDB entries.
+    Returns:
+        id_list:
+            list:   A list of RethinkDB UUIDs taken from `entries`
+    """
+    id_list = []
+    for entry in entries:
+        id_list.append(entry["id"])
+    return id_list
+
+
+def log_rethink_response(response, action):
+    """Process RethinkDB CRUD response and appropriately log the results.
+
+    Args:
+        response:
+            obj:    A dict containing a response from a rethinkDB operation.
+        action:
+            str:    The RethinkDB operation that was meant to be performed.
+                    ex: deleted|inserted|replaced
+    """
+    for key in response:
+        if key == action and response[key] > 0:
+            LOGGER.info("Successfully %s %s outbound entries.", key, response[key])
+        elif key != "error" and response[key] > 0:
+            LOGGER.warning("%s %s outbound entries.", key, response[key])
+        elif response[key] > 0:
+            LOGGER.error(
+                "%s %s occurred during rethink transaction.", response[key], key
+            )

--- a/rbac/providers/ldap/delta_outbound_sync.py
+++ b/rbac/providers/ldap/delta_outbound_sync.py
@@ -27,10 +27,7 @@ from rbac.providers.common.db_queries import (
     put_entry_changelog,
     update_outbound_entry_status,
 )
-from rbac.providers.common.outbound_filters import (
-    outbound_user_filter,
-    outbound_group_filter,
-)
+from rbac.providers.common.outbound_filters import outbound_group_filter
 from rbac.providers.common.provider_errors import ValidationException
 from rbac.providers.ldap.ldap_validator import validate_update_entry
 
@@ -71,7 +68,8 @@ def process_outbound_entry(queue_entry, ldap_connection):
     if data_type == "group":
         sawtooth_entry_filtered = outbound_group_filter(queue_entry["data"], "ldap")
     elif data_type == "user":
-        sawtooth_entry_filtered = outbound_user_filter(queue_entry["data"], "ldap")
+        # Outbound AD user changes is currently not supported
+        return False
 
     object_def = ObjectDef(data_type, ldap_connection)
     reader_cursor = Reader(ldap_connection, object_def, distinguished_name)


### PR DESCRIPTION
* Compare inbound delta sync entries against the outbound queue to remove:
  * Ingested operations that originated from NEXT.
  * Race conditions where an operation originating in next was also performed 
    on the remote rebac provider (in which case the NEXT entry should be 
    authoritative.
* Duplicate inbound entries should be dropped, while outbound entries should
  be marked `CONFIRMED`, if not already, and then deleted.

Signed-off-by: jbobo <j.ned@bobonana.me>