### PR TITLE
Add swagger for Users endpoints

### DIFF
--- a/rbac/server/api/main.py
+++ b/rbac/server/api/main.py
@@ -78,6 +78,15 @@ def load_config(app):
     app.config.API_PRODUCES_CONTENT_TYPES = ["application/json"]
     app.config.API_SCHEMES = ["http", "https"]
     app.config.API_TITLE = "Sawtooth Next Directory API"
+    app.config.API_SECURITY = [{"authToken": []}]
+    app.config.API_SECURITY_DEFINITIONS = {
+        "authToken": {
+            "type": "apiKey",
+            "in": "header",
+            "name": "Authorization",
+            "description": "Paste your auth token.",
+        }
+    }
     app.config.BATCHER_KEY_PAIR = Key()
     app.config.CHATBOT_HOST = get_config("CHATBOT_HOST")
     app.config.CHATBOT_PORT = get_config("CHATBOT_PORT")

--- a/tests/integration/server/api/users_api_tests.py
+++ b/tests/integration/server/api/users_api_tests.py
@@ -483,7 +483,7 @@ def test_update_user():
         password_response = session2.put(
             "http://rbac-server:8000/api/users/update", json=update_payload
         )
-        assert password_response.status_code == 400
+        assert password_response.status_code == 403
         assert (
             password_response.json()["message"] == "You are not a NEXT Administrator."
         )


### PR DESCRIPTION
* Use sanic-openapi decorators to add swagger docs for users endpoints.
* Remove duplicate endpoint (front-end team confirmed it was unneeded).
* Add auth settings for openapi 

[Issue #622]

Signed-off-by: jbobo <j.ned@bobonana.me>