### PR TITLE
Salt passwords before hashing

### DIFF
--- a/docker/rbac.server.Dockerfile
+++ b/docker/rbac.server.Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update -y && \
         apt-file update && \
         apt-get install -y gcc
 RUN pip install \
+        bcrypt==3.1.7 \
         grpcio-tools==1.16.1 \
         itsdangerous==1.1.0 \
         rethinkdb==2.3.0.post6 \

--- a/rbac/server/db/users_query.py
+++ b/rbac/server/db/users_query.py
@@ -378,7 +378,7 @@ async def users_search_duplicate(conn, username):
     return resource
 
 
-async def update_user_password(conn, next_id, password):
+async def update_user_password(conn, next_id, hashed_password, salt):
     """Update a user's password by next_id
     Args:
         conn:
@@ -391,7 +391,7 @@ async def update_user_password(conn, next_id, password):
     resource = (
         await r.table("auth")
         .filter({"next_id": next_id})
-        .update({"hashed_password": password})
+        .update({"hashed_password": hashed_password, "salt": salt})
         .coerce_to("array")
         .run(conn)
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 PyYAML==4.2b1
+bcrypt==3.1.7
 black==18.9b0
 environs==4.1.0
 itsdangerous==0.24


### PR DESCRIPTION
* Renamed "password" field in auth table to "hashed password".i
* Added "salt" field in auth table.
* Switched hashing function to `hashlib.pbkdf2_hmac`.
* Switched to `hmac.compare_digest.compare_hash()` to prevent timing attacks.
* Added salt generated by `os.urandom(60)`.

[ Issue #224 ]

Signed-off-by: jbobo <j.ned@bobonana.me>