### PR TITLE
Secure Search API

### DIFF
--- a/tests/integration/server/api/search_api_tests.py
+++ b/tests/integration/server/api/search_api_tests.py
@@ -40,5 +40,5 @@ def test_search_api():
             }
         }
         response = session.post("http://rbac-server:8000/api/search", json=search_query)
-        assert response.json()["data"] == {"roles": [], "packs": [], "users": []}
+        assert response.json().get("data") == {"roles": [], "packs": [], "users": []}
         delete_user_by_username("susan23")

--- a/tests/unit/server/search_api_tests.py
+++ b/tests/unit/server/search_api_tests.py
@@ -15,11 +15,7 @@
 """Test Suite for Search API."""
 import pytest
 
-from rbac.server.api.search import (
-    get_total_pages,
-    search_paginate,
-    validate_search_payload,
-)
+from rbac.server.api.search import get_total_pages, search_paginate
 
 PAGINATION_TEST_CASES = [
     (20, 1, (0, 20)),
@@ -60,30 +56,3 @@ def test_get_total_no_inputs():
     """Test get_total_pages with no parameters submitted. (Default 0)."""
     result = search_paginate()
     assert result == (0, 50)
-
-
-def test_validate_search():
-    """Test validate_search_payload works with a good payload."""
-    payload = {"search_input": "The input", "search_object_types": []}
-    result = validate_search_payload(payload)
-    assert result == {}
-
-
-def test_validate_search_no_query():
-    """Test validation of an empty value for search query."""
-    result = validate_search_payload(None)
-    assert result["errors"] == "No query parameter received."
-
-
-def test_validate_search_no_input():
-    """Test validation of an empty value for search_input."""
-    payload = {"search_object_types": []}
-    result = validate_search_payload(payload)
-    assert result["errors"] == "No search_input string for search received."
-
-
-def tests_validate_search_no_types():
-    """Test validation of an empty value for search_object types."""
-    payload = {"search_input": "The input"}
-    result = validate_search_payload(payload)
-    assert result["errors"] == "No search_object_types for search received."


### PR DESCRIPTION
* Add input processign to prevent abuse of the search API:
  * Escape regex in user supplied search query
  * limit user supplied search query to 255 characters.

[ Issue: #581 ]

Signed-off-by: jbobo <j.ned@bobonana.me>