### PR TITLE
Remove warnings from integration tests

### DIFF
--- a/tests/integration/server/api/roles_api_tests.py
+++ b/tests/integration/server/api/roles_api_tests.py
@@ -706,7 +706,7 @@ def test_delete_role_with_members():
         # Wait for member in rethinkdb
         is_member_in_db = wait_for_resource_in_db("role_members", "related_id", user_id)
         assert (
-            is_member_in_db is True,
+            is_member_in_db is True
         ), "Couldn't find member in rethinkdb, maximum attempts exceeded."
 
         # Delete test role

--- a/tests/utilities/db_queries.py
+++ b/tests/utilities/db_queries.py
@@ -135,10 +135,8 @@ def wait_for_resource_in_db(table, index, identifier, max_attempts=15, delay=0.3
     count = 0
     with connect_to_db() as conn:
         while not resource_found and count < max_attempts:
-            resource = (
-                r.table(table).filter({index: identifier}).coerce_to("array").run(conn)
-            )
-            if resource:
+            resource = r.table(table).filter({index: identifier}).count().run(conn)
+            if resource > 0:
                 resource_found = True
             count += 1
             time.sleep(delay)


### PR DESCRIPTION
 A test utility function was written in such a way as to cause warnings in integration tests. Refactored that utility function to address the warning.